### PR TITLE
Make `current_century` handle custom Date string formatters

### DIFF
--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -16,7 +16,8 @@ module InterpretDate
   private
 
   def current_century
-    "#{Date.today.to_s[0..1]}00".to_i
+    year = Date.today.year
+    "#{year.to_s[0..1]}00".to_i
   end
 
   def contains_only_six_digits(value)

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
In the event that the default Date string formatter is overwritten we
can't rely on the year being the first part of the string. To combat
this we're explicitly extracting th year and then creating the current
century from there.
