### PR TITLE
Support yyyy-mm-dd date string format

### DIFF
--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -37,7 +37,9 @@ module InterpretDate
       year  = date_input[4,2].to_i
     elsif slash_based_date(date_input)
       # Break the string apart using the delimiters '-', '/', and '.', making each element an integer
-      month, day, year = date_input.split(/[-\.\/]+/).collect { |element| element.to_i }
+      month, day, year = split(date_input)
+    elsif database_date(date_input)
+      year, month, day = split(date_input)
     else
       return nil
     end
@@ -63,6 +65,10 @@ module InterpretDate
     end
   end
 
+  def split(date_input)
+    date_input.split(/[-\.\/]+/).collect(&:to_i)
+  end
+
   # -----------------------------------------
   # Does the input string match this pattern
   # and associated variations?
@@ -75,5 +81,14 @@ module InterpretDate
   # -----------------------------------------
   def slash_based_date(value)
     /^\d{1,2}([-\.\/]+)\d{1,2}\1\d{2,4}$/ =~ value
+  end
+
+  # -----------------------------------------
+  # Does the input string match this pattern
+  # and associated variations?
+  #  * yyyy/mm/dd
+  #  * yyyy-mm-dd
+  def database_date(value)
+    /^\d{4}([-\.\/]+)\d{2}\1\d{2}$/ =~ value
   end
 end

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/interpret_date_spec.rb
+++ b/spec/interpret_date_spec.rb
@@ -10,14 +10,17 @@ RSpec.describe InterpretDate do
       "m/d/yyyy" => "2/6/1990",
       "mm/dd/yy" => "02/06/90",
       "mm/dd/yyyy" => "02/06/1990",
+      "yyyy/mm/dd" => "1990/02/06",
       "m-d-yy" => "2-6-90",
       "m-d-yyyy" => "2-6-1990",
       "mm-dd-yy" => "02-06-90",
       "mm-dd-yyyy" => "02-06-1990",
+      "yyyy-mm-dd" => "1990-02-06",
       "m.d.yy" => "2.6.90",
       "m.d.yyyy" => "2.6.1990",
       "mm.dd.yy" => "02.06.90",
       "mm.dd.yyyy" => "02.06.1990",
+      "yyyy.mm.dd" => "1990.02.06",
     }.each do |format, value|
       it "interprets dates in the form of #{format} properly" do
         expect(interpret_date(value)).to eq(test_date)


### PR DESCRIPTION
This commit adds #database_date to identify the situation where the date
string format is year/month/day as opposed to month/day/year.

