### PR TITLE
Support db formatted date strings

### DIFF
--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -35,6 +35,8 @@ module InterpretDate
       month = date_input[0,2].to_i
       day   = date_input[2,2].to_i
       year  = date_input[4,2].to_i
+    elsif db_formatted_date(date_input)
+      year, month, day = date_input.split("-").collect { |element| element.to_i }
     elsif slash_based_date(date_input)
       # Break the string apart using the delimiters '-', '/', and '.', making each element an integer
       month, day, year = date_input.split(/[-\.\/]+/).collect { |element| element.to_i }
@@ -75,5 +77,10 @@ module InterpretDate
   # -----------------------------------------
   def slash_based_date(value)
     /^\d{1,2}([-\.\/]+)\d{1,2}\1\d{2,4}$/ =~ value
+  end
+
+  # Example: 2017-01-01
+  def db_formatted_date(value)
+    /^\d{4}-\d{2}-\d{2}$/ =~ value
   end
 end

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end

--- a/spec/interpret_date_spec.rb
+++ b/spec/interpret_date_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe InterpretDate do
     it "returns nil if the input passed in cannot be parsed into a date" do
       expect(interpret_date("Kevin Bacon")).to eq(nil)
     end
+
+    context "when the date is a db formatted string" do
+      it "interprets the string as a date" do
+        expect(interpret_date("2017-01-01")).to eql(Date.new(2017, 01, 01))
+      end
+    end
   end
 
   describe "#interpret_dob_date" do


### PR DESCRIPTION
This commit adds support for interpreting db formatted strings, which
will specifically be used when parsing dates sent through the Viper API.

