### PR TITLE
Update .travis.yml ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 
 rvm:
-  - 1.9.3
-  - 2.0
   - 2.1
   - 2.2
+  - ruby-2.3.1
+  - ruby-2.4.0

--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -1,3 +1,4 @@
+require "date"
 require "interpret_date/version"
 
 module InterpretDate

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
This commit changes the versions of ruby that we're testing
against on travis to only include the versions that are currently
still receiving some sort of support (whether official support or
security maintenance). This also adds the most recent version
of ruby (2.4.0).