### PR TITLE
Create interpret_date_assignment_for class method

### DIFF
--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -2,6 +2,24 @@ require "date"
 require "interpret_date/version"
 
 module InterpretDate
+  def self.included base
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    def interpret_date_assignment_for(*attributes)
+      attributes.map(&:to_s).each do |field|
+        define_method("#{field}=".to_sym) do |value|
+          if defined?(super)
+            super(interpret_date(value) || value)
+          else
+            instance_variable_set("@#{field}", interpret_date(value) || value)
+          end
+        end
+      end
+    end
+  end
+
   def interpret_date(date_input, buffer = 10)
     # the number of years previous turn of the century + buffer number of years
     @century_divider = Date.today.year + buffer - current_century

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.2.0"
+  VERSION = "2.0.0"
 end

--- a/spec/interpret_date_spec.rb
+++ b/spec/interpret_date_spec.rb
@@ -74,4 +74,32 @@ RSpec.describe InterpretDate do
       end
     end
   end
+
+  describe "#interpret_date_assignment_for" do
+    class TestBase
+      attr_reader :field1
+      def field1=(value)
+        @field1 = value - 1
+      end
+    end
+
+    class Test < TestBase
+      include InterpretDate
+      attr_accessor :field2
+      interpret_date_assignment_for :field1, :field2
+    end
+
+    let(:test_object) { Test.new }
+    let(:test_date) { "2/6/1990" }
+
+    it "creates an attribute assignment method that calls interpret_date" do
+      expect(test_object).to receive(:interpret_date).with(test_date).and_call_original.twice
+
+      test_object.field1 = test_date
+      expect(test_object.field1).to eq(Date.new(1990, 2, 5))
+
+      test_object.field2 = test_date
+      expect(test_object.field2).to eq(Date.new(1990, 2, 6))
+    end
+  end
 end


### PR DESCRIPTION
Our usage of the interpret_date gem has created a pattern of defining
several assignment methods with the same logic inside of them which is
not helpful in the model and can clutter them with enough dates defined.
This commit introduces a class method that is included with
`InterpretDate` that allows you to define the attributes which need
their assignment interpreted by interpret date so we can clean up the
models.

_Old example_:
```rb
class Payment < ApplicationRecord
  include InterpretDate

  def issued_date=(value)
    super(interpret_date(value) || value)
  end

  def paid_date=(value)
    super(interpret_date(value) || value)
  end

  def sent_date=(value)
    super(interpret_date(value) || value)
  end

  def voided_date=(value)
    super(interpret_date(value) || value)
  end
end
```

_New example_:
```rb
class Payment < ApplicationRecord
  include InterpretDate

  interpret_date_assignment_for :issued_date,
    :paid_date,
    :sent_date,
    :voided_date,
end
```