### PR TITLE
Add DateType to interpret date for rails dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Or install it yourself as:
 
 ## Usage
 
+### Instance Methods
+
 To utilize `interpret_date`, mix in the `InterpretDate` module into a
 class that needs to interpret American formatted dates into ruby Date
 objects and pass the date string into the `interpret_date` or
@@ -39,6 +41,31 @@ class Parcel < ActiveRecord::Base
   def birthdate=(value)
     super(interpret_dob_date(value))
   end
+end
+```
+
+### ActiveRecord Date Type
+
+You can also utilize `InterpretDate` with the ActiveRecord Attribute
+API to automatically cast dates with their interpreted values.
+
+```ruby
+class Parcel < ActiveRecord::Base
+  attribute :shipping_date, InterpretDate::DateType.new
+end
+```
+
+If you plan on using the Date Type extensively you can register it in
+an initializer.
+
+```ruby
+# config/initializers/types.rb
+ActiveRecord::Type.register(:interpreted_date, InterpretDate::DateType)
+```
+
+```ruby
+class Parcel < ActiveRecord::Base
+  attribute :shipping_date, :interpreted_date
 end
 ```
 

--- a/interpret_date.gemspec
+++ b/interpret_date.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "activerecord", ">=4.2"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.2"

--- a/lib/interpret_date.rb
+++ b/lib/interpret_date.rb
@@ -1,4 +1,5 @@
 require "date"
+require "interpret_date/date_type"
 require "interpret_date/version"
 
 module InterpretDate

--- a/lib/interpret_date/date_type.rb
+++ b/lib/interpret_date/date_type.rb
@@ -1,0 +1,11 @@
+require "active_record"
+
+module InterpretDate
+  class DateType < ActiveRecord::Type::Date
+    include InterpretDate
+
+    def cast(value)
+      super(interpret_date(value) || value)
+    end
+  end
+end

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Our usage of the `interpret_date` gem has created a pattern of defining
several assignment methods with the same logic inside of them which is
not helpful in the model and can clutter them with enough dates defined.
This commit introduces a `DateType` class that can be used by the
ActiveRecord attributes API that automatically casts the type value
using `interpret_date` so we don't have to override Model attribute
writers in applications anymore.

