### PR TITLE
Update gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 
 rvm:
-  - 2.1
   - 2.2
   - ruby-2.3.1
   - ruby-2.4.0

--- a/interpret_date.gemspec
+++ b/interpret_date.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">=4.2"
+  spec.add_runtime_dependency "activerecord", "~> 5.1"
   spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
In order to remove warnings when building the gem, this pull request
removes any open-ended dependency requirements.