### PR TITLE
Update to support Rails 7

### DIFF
--- a/interpret_date.gemspec
+++ b/interpret_date.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', ['>= 5.1', '< 7']
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake", "~> 12"
-  spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_runtime_dependency 'activerecord', '<= 7'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 end

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.3.5"
+  VERSION = "1.3.6"
 end


### PR DESCRIPTION
This commit updates the rails dependencies to support rails 7. As part
of this commit the version constraints on the other gems were removed in
order to support all versions of rails under version 7.
