### PR TITLE
Make gem work with all versions of rails less than version 8

### DIFF
--- a/interpret_date.gemspec
+++ b/interpret_date.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '<= 7'
+  spec.add_runtime_dependency 'activerecord', '< 8'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end


### PR DESCRIPTION
In order to make this gem work with all version of rails that have
official releases, this commit updates the constraints on the
activerecord for anything less than version 8. Due to the patch the
version was bumped to `1.3.7` in this commit.