### PR TITLE
Support Rails 8

### DIFF
--- a/interpret_date.gemspec
+++ b/interpret_date.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'activerecord', '< 8'
+  spec.add_runtime_dependency 'activerecord', '< 9'
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/interpret_date/version.rb
+++ b/lib/interpret_date/version.rb
@@ -1,3 +1,3 @@
 module InterpretDate
-  VERSION = "1.3.7"
+  VERSION = "1.3.8"
 end


### PR DESCRIPTION
Widen the activerecord constraint from < 8 to < 9 so the gem can be used with Rails 8. InterpretDate::DateType subclasses ActiveRecord::Type::Date, which is unchanged in Rails 8; the spec suite passes against activerecord 8.1.3.

[1215282201370397](https://app.asana.com/0/0/1215282201370397/f)